### PR TITLE
Language identifier change

### DIFF
--- a/VersionResource.rc
+++ b/VersionResource.rc
@@ -20,7 +20,7 @@ VS_VERSION_INFO VERSIONINFO
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "041904b0"
+        BLOCK "000904b0"
         BEGIN
             VALUE "Comments", PRODUCT_COMMENTS
             VALUE "CompanyName", PRODUCT_COMPANY_NAME
@@ -35,6 +35,6 @@ BEGIN
     END
     BLOCK "VarFileInfo"
     BEGIN
-        VALUE "Translation", 0x419, 1200
+        VALUE "Translation", 0x9, 1200
     END
 END


### PR DESCRIPTION
Changing the language block identifier from Russian to English. So now it is visible on non-Russian localizations.