### PR TITLE
Fix building with mingw-w64

### DIFF
--- a/VersionResource.rc
+++ b/VersionResource.rc
@@ -1,5 +1,17 @@
 #include "VersionInfo.h"
-#include "winres.h"
+
+#if defined(__MINGW64__) || defined(__MINGW32__)
+	// MinGW-w64, MinGW
+	#if defined(__has_include) && __has_include(<winres.h>)
+		#include <winres.h>
+	#else
+		#include <afxres.h>
+		#include <winresrc.h>
+	#endif
+#else
+	// MSVC, Windows SDK
+	#include <winres.h>
+#endif
 
 IDI_ICON1               ICON                    PRODUCT_ICON
 


### PR DESCRIPTION
This PR adds support for building with mingw32-w64. It does not come with the `winres.h`, but `afxres.h`. This PR chooses the correct header.