### PR TITLE
Support multiple targets in single CMakeLists.txt

### DIFF
--- a/VersionResource.rc
+++ b/VersionResource.rc
@@ -1,4 +1,4 @@
-#include "VersionInfo.h"
+#include "@PRODUCT_VERSION_HEADER@"
 
 #if defined(__MINGW64__) || defined(__MINGW32__)
 	// MinGW-w64, MinGW

--- a/generate_product_version.cmake
+++ b/generate_product_version.cmake
@@ -4,7 +4,7 @@ set (GenerateProductVersionCurrentDir ${CMAKE_CURRENT_LIST_DIR})
 
 # generate_product_version() function
 #
-# This function uses VersionInfo.in template file and VersionResource.rc file
+# This function uses ${NAME}_VersionInfo.in template file and ${NAME}_VersionResource.rc file
 # to generate WIN32 resource with version information and general resource strings.
 #
 # Usage:

--- a/generate_product_version.cmake
+++ b/generate_product_version.cmake
@@ -4,7 +4,7 @@ set (GenerateProductVersionCurrentDir ${CMAKE_CURRENT_LIST_DIR})
 
 # generate_product_version() function
 #
-# This function uses ${NAME}_VersionInfo.in template file and ${NAME}_VersionResource.rc file
+# This function uses VersionInfo.in template file and VersionResource.rc file
 # to generate WIN32 resource with version information and general resource strings.
 #
 # Usage:

--- a/generate_product_version.cmake
+++ b/generate_product_version.cmake
@@ -92,8 +92,9 @@ function(generate_product_version outfiles)
         set(PRODUCT_FILE_DESCRIPTION "${PRODUCT_NAME}")
     endif()
 
-    set (_VersionInfoFile ${CMAKE_CURRENT_BINARY_DIR}/VersionInfo.h)
-    set (_VersionResourceFile ${CMAKE_CURRENT_BINARY_DIR}/VersionResource.rc)
+    set (_VersionInfoFile ${CMAKE_CURRENT_BINARY_DIR}/${PRODUCT_NAME}_VersionInfo.h)
+    set (_VersionResourceFile ${CMAKE_CURRENT_BINARY_DIR}/${PRODUCT_NAME}_VersionResource.rc)
+    set(PRODUCT_VERSION_HEADER ${_VersionInfoFile})
     configure_file(
         ${GenerateProductVersionCurrentDir}/VersionInfo.in
         ${_VersionInfoFile}
@@ -101,7 +102,7 @@ function(generate_product_version outfiles)
     configure_file(
         ${GenerateProductVersionCurrentDir}/VersionResource.rc
         ${_VersionResourceFile}
-        COPYONLY)
+        @ONLY)
     list(APPEND ${outfiles} ${_VersionInfoFile} ${_VersionResourceFile})
     set (${outfiles} ${${outfiles}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Previous version uses fixed file named `VersionInfo.h` and `VersionResource.rc`, which will override previous target set in the same `CMakeLists.txt`.

This pr uses `${NAME}_VersionInfo.h` and `${NAME}_VersionResource.rc` to avoid the problem.